### PR TITLE
Set up GCM payloads to be structured properly

### DIFF
--- a/app/models/notification/factory.rb
+++ b/app/models/notification/factory.rb
@@ -16,18 +16,21 @@ class Notification::Factory
     title { I18n.t('notification_factory.repost.title') }
     body { I18n.t('notification_factory.repost.body', username: related_object.author.username) }
     application_target { "notifications/posts/#{related_object.id}" }
+    web_url { related_object.href }
   end
 
   register_type ElloProtobufs::NotificationType::POST_COMMENT, 'post_comment' do |related_object|
     title { I18n.t('notification_factory.post_comment.title') }
     body { I18n.t('notification_factory.post_comment.body', username: related_object.author.username) }
     application_target { "notifications/posts/#{related_object.parent_post.id}/comments/#{related_object.id}" }
+    web_url { related_object.parent_post.href }
   end
 
   register_type ElloProtobufs::NotificationType::REPOST_COMMENT_TO_REPOST_AUTHOR, 'repost_comment_to_repost_author' do |related_object|
     title { I18n.t('notification_factory.repost_comment_to_repost_author.title') }
     body { I18n.t('notification_factory.repost_comment_to_repost_author.body', username: related_object.author.username) }
     application_target { "notifications/posts/#{related_object.parent_post.id}/comments/#{related_object.id}" }
+    web_url { related_object.parent_post.href }
   end
 
   register_type ElloProtobufs::NotificationType::REPOST_COMMENT_TO_ORIGINAL_AUTHOR, 'repost_comment_to_original_author' do |related_object|
@@ -38,18 +41,21 @@ class Notification::Factory
              reposter_username: related_object.parent_post.author.username)
     end
     application_target { "notifications/posts/#{related_object.parent_post.id}/comments/#{related_object.id}" }
+    web_url { related_object.parent_post.href }
   end
 
   register_type ElloProtobufs::NotificationType::POST_LOVE, 'post_love' do |related_object|
     title { I18n.t('notification_factory.post_love.title') }
     body { I18n.t('notification_factory.post_love.body', username: related_object.user.username) }
     application_target { "notifications/posts/#{related_object.post.id}" }
+    web_url { related_object.post.href }
   end
 
   register_type ElloProtobufs::NotificationType::REPOST_LOVE_TO_REPOST_AUTHOR, 'repost_love_to_repost_author' do |related_object|
     title { I18n.t('notification_factory.repost_love_to_repost_author.title') }
     body { I18n.t('notification_factory.repost_love_to_repost_author.body', username: related_object.user.username) }
     application_target { "notifications/posts/#{related_object.post.id}" }
+    web_url { related_object.post.href }
   end
 
   register_type ElloProtobufs::NotificationType::REPOST_LOVE_TO_ORIGINAL_AUTHOR, 'repost_love_to_original_author' do |related_object|
@@ -60,30 +66,35 @@ class Notification::Factory
              reposter_username: related_object.post.author.username)
     end
     application_target { "notifications/posts/#{related_object.post.id}" }
+    web_url { related_object.post.href }
   end
 
   register_type ElloProtobufs::NotificationType::POST_MENTION, 'post_mention' do |related_object|
     title { I18n.t('notification_factory.post_mention.title') }
     body { I18n.t('notification_factory.post_mention.body', username: related_object.author.username) }
     application_target { "notifications/posts/#{related_object.id}" }
+    web_url { related_object.href }
   end
 
   register_type ElloProtobufs::NotificationType::COMMENT_MENTION, 'comment_mention' do |related_object|
     title { I18n.t('notification_factory.comment_mention.title') }
     body { I18n.t('notification_factory.comment_mention.body', username: related_object.author.username) }
     application_target { "notifications/posts/#{related_object.parent_post.id}/comments/#{related_object.id}" }
+    web_url { related_object.parent_post.href }
   end
 
   register_type ElloProtobufs::NotificationType::FOLLOWER, 'follower' do |related_object|
     title { I18n.t('notification_factory.follower.title') }
     body { I18n.t('notification_factory.follower.body', username: related_object.username) }
     application_target { "notifications/users/#{related_object.id}" }
+    web_url { related_object.href }
   end
 
   register_type ElloProtobufs::NotificationType::INVITE_REDEMPTION, 'invite_redemption' do |related_object|
     title { I18n.t('notification_factory.invite_redemption.title') }
     body { I18n.t('notification_factory.invite_redemption.body', username: related_object.username) }
     application_target { "notifications/users/#{related_object.id}" }
+    web_url { related_object.href }
   end
 
   register_type ElloProtobufs::NotificationType::RESET_BADGE_COUNT, 'reset_badge_count' do |_|

--- a/app/models/notification/factory/type_decorator.rb
+++ b/app/models/notification/factory/type_decorator.rb
@@ -17,6 +17,10 @@ class Notification::Factory::TypeDecorator
     def application_target
       @application_target = yield
     end
+
+    def web_url
+      @web_url = yield
+    end
   end
 
   def initialize(type, human_readable_type, dsl_block)
@@ -33,6 +37,7 @@ class Notification::Factory::TypeDecorator
     notification.body = @body
     notification.metadata[:type] = @human_readable_type
     notification.metadata[:application_target] = @application_target
+    notification.metadata[:web_url] = @web_url
 
     reset
   end

--- a/spec/interactors/gcm/deliver_notification_spec.rb
+++ b/spec/interactors/gcm/deliver_notification_spec.rb
@@ -49,16 +49,15 @@ describe GCM::DeliverNotification do
 
       it 'nests the notification data inside the production message container' do
         expected_message = {
-            'GCM' => {
-                aps: {
-                    badge: notification.badge_count,
-                    alert: {
-                        title: notification.title,
-                        body: notification.body
-                    }
-                },
+          'GCM' => {
+              data: {
                 some_key: 'value'
-            }.to_json
+              },
+              notification: {
+                title: notification.title,
+                body: notification.body
+              }
+          }.to_json
         }
 
         expect(SnsService).to receive(:deliver_notification).with(anything, expected_message)
@@ -71,7 +70,7 @@ describe GCM::DeliverNotification do
         it 'does not include the alert in the payload' do
           expected_message = {
               'GCM' => {
-                  aps: { badge: notification.badge_count }
+                data: { }
               }.to_json
           }
 

--- a/spec/models/notification/factory_spec.rb
+++ b/spec/models/notification/factory_spec.rb
@@ -30,6 +30,7 @@ describe Notification::Factory do
       let(:title) { 'New Repost' }
       let(:body) { "#{repost.author.username} has reposted one of your posts" }
       let(:application_target) { post_target(repost.id) }
+      let(:web_url) { repost.href }
     end
   end
 
@@ -45,6 +46,7 @@ describe Notification::Factory do
       let(:title) { 'New Comment' }
       let(:body) { "#{comment.author.username} commented on your post" }
       let(:application_target) { comment_target(comment.parent_post.id, comment.id) }
+      let(:web_url) { comment.parent_post.href }
     end
   end
 
@@ -61,6 +63,7 @@ describe Notification::Factory do
       let(:title) { 'New Comment on Your Repost' }
       let(:body) { "#{comment.author.username} commented on your repost" }
       let(:application_target) { comment_target(comment.parent_post.id, comment.id) }
+      let(:web_url) { repost.href }
     end
   end
 
@@ -77,6 +80,7 @@ describe Notification::Factory do
       let(:title) { 'New Comment on a Repost of Your Post' }
       let(:body) { "#{comment.author.username} commented on #{comment.parent_post.author.username}'s repost of your post" }
       let(:application_target) { comment_target(comment.parent_post.id, comment.id) }
+      let(:web_url) { repost.href }
     end
   end
 
@@ -92,6 +96,7 @@ describe Notification::Factory do
       let(:title) { 'New Love' }
       let(:body) { "#{love.user.username} loved your post" }
       let(:application_target) { post_target(love.post.id) }
+      let(:web_url) { love.post.href }
     end
   end
 
@@ -108,6 +113,7 @@ describe Notification::Factory do
       let(:title) { 'New Love on Your Repost' }
       let(:body) { "#{love.user.username} loved your repost" }
       let(:application_target) { post_target(love.post.id) }
+      let(:web_url) { love.post.href }
     end
   end
 
@@ -124,6 +130,7 @@ describe Notification::Factory do
       let(:title) { 'New Love on a Repost of Your Post' }
       let(:body) { "#{love.user.username} loved #{love.post.author.username}'s repost of your post" }
       let(:application_target) { post_target(love.post.id) }
+      let(:web_url) { love.post.href }
     end
   end
 
@@ -139,6 +146,7 @@ describe Notification::Factory do
       let(:title) { 'New Post Mention' }
       let(:body) { "#{post.author.username} mentioned you in a post" }
       let(:application_target) { post_target(post.id) }
+      let(:web_url) { post.href }
     end
   end
 
@@ -154,6 +162,7 @@ describe Notification::Factory do
       let(:title) { 'New Comment Mention' }
       let(:body) { "#{comment.author.username} mentioned you in a comment" }
       let(:application_target) { comment_target(comment.parent_post.id, comment.id) }
+      let(:web_url) { comment.parent_post.href }
     end
   end
 
@@ -169,10 +178,11 @@ describe Notification::Factory do
       let(:title) { 'New Follower' }
       let(:body) { "#{user.username} is now following you" }
       let(:application_target) { user_target(user.id) }
+      let(:web_url) { user.href }
     end
   end
 
-  describe 'building a follower notification' do
+  describe 'building an invite redemption notification' do
     let(:user) { create(:protobuf_user) }
 
     subject { described_class.build(ElloProtobufs::NotificationType::INVITE_REDEMPTION, destination_user, user) }
@@ -184,6 +194,7 @@ describe Notification::Factory do
       let(:title) { 'New Friends on Ello' }
       let(:body) { "#{user.username} has accepted your invitation to join Ello" }
       let(:application_target) { user_target(user.id) }
+      let(:web_url) { user.href }
     end
   end
 
@@ -197,6 +208,7 @@ describe Notification::Factory do
       let(:title) { nil }
       let(:body) { nil }
       let(:application_target) { nil }
+      let(:web_url) { nil }
     end
   end
 

--- a/spec/support/shared_examples/a_notification_with.rb
+++ b/spec/support/shared_examples/a_notification_with.rb
@@ -27,5 +27,9 @@ RSpec.shared_examples 'a notification with' do
   it 'sets the correct application_target' do
     expect(subject.metadata[:application_target]).to eq(application_target)
   end
+
+  it 'sets the correct web_url' do
+    expect(subject.metadata[:web_url]).to eq(web_url)
+  end
 end
 


### PR DESCRIPTION
Include a `notification` key with title/body/icon and a `data` key with the relevant metadata for GCM.

Add a `web_url` key to metadata for both APNS and GCM so we can always locate the web-equivalent page for the push.