### PR TITLE
Remove failed push tokens

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+ruby:
+  enabled: true
+  config_file: .rubocop.yml
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,54 @@
+ClassAndModuleChildren:
+  Include:
+    - lib/**/*.rb
+Documentation:
+  Enabled: false
+EmptyLinesAroundBlockBody:
+  Enabled: false
+EmptyLinesAroundClassBody:
+  Enabled: false
+EmptyLinesAroundModuleBody:
+  Enabled: false
+ExtraSpacing:
+  Enabled: false
+LineLength:
+  # Default is that lines should be 80, but that's somewhat noisy. We want a softer limit.
+  Description: Limit lines to 120 characters.
+  Max: 120
+  Exclude:
+    - config/routes.rb
+Lint/EndAlignment:
+  # The value `keyword` means that `end` should be aligned with the matching
+  # keyword (if, while, etc.).
+  # The value `variable` means that in assignments, `end` should be aligned
+  # with the start of the variable on the left hand side of `=`. In all other
+  # situations, `end` should still be aligned with the keyword.
+  AlignWith: variable
+  SupportedStyles:
+    - keyword
+    - variable
+Lint/UnusedMethodArgument:
+  Exclude:
+    - app/interactors/**/*.rb
+Lint/UselessAccessModifier:
+  Enabled: false
+SingleSpaceBeforeFirstArg:
+  Enabled: false
+SpaceInsideBrackets:
+  Enabled: false
+StringLiterals:
+  EnforcedStyle: single_quotes
+  Enabled: true
+Style/Blocks:
+  Enabled: false
+Style/CollectionMethods:
+  PreferredMethods:
+    find: 'detect'
+Style/BracesAroundHashParameters:
+  EnforcedStyle: context_dependent
+  SupportedStyles:
+    - braces
+    - no_braces
+    - context_dependent
+Style/IndentHash:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
 rvm: 2.2.2
 before_script:
 - cp .env.example .env
+- cp config/database.travis.yml config/database.yml
 script:
 - bundle exec rake db:drop:all db:create:all db:schema:load
 - bundle exec rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,6 +257,3 @@ DEPENDENCIES
   retries
   rspec-rails (~> 3.0)
   shoulda-matchers
-
-BUNDLED WITH
-   1.11.2

--- a/app/controllers/callbacks/aws_controller.rb
+++ b/app/controllers/callbacks/aws_controller.rb
@@ -2,17 +2,13 @@ require 'json'
 
 # heavily influenced by the approach used in
 # http://www.downrightlies.net/posts/2015/05/19/setting-up-ses-on-aws-to-send-emails-from-rails.html
-class Callbacks::AWSController < ApplicationController
+class Callbacks::AwsController < ApplicationController
 
-  before_action :log_incoming_message
+  before_action :log_incoming_message, :confirm_subscription, :verify_message_authenticity
+  skip_before_filter :require_binary_request
+  before_filter :require_json_request
 
   def push_failed
-
-    if !aws_message.authentic?
-      Rails.logger.info "Not an authentic SNS message - exiting"
-      return render json: {}
-    end
-
     if !is_failure_notification?
       Rails.logger.info "Not a Failure Notification - exiting"
       return render json: {}
@@ -27,13 +23,37 @@ class Callbacks::AWSController < ApplicationController
 
   private
 
+  def require_json_request
+    render nothing: true, status: 406 unless request.content_type == 'application/json' || request.headers["Accept"] =~ /json/
+  end
+
+  def confirm_subscription
+    if type == 'SubscriptionConfirmation'
+      client = Aws::SNS::Client.new
+      resp = client.confirm_subscription({
+        topic_arn: topic_arn, # required
+        token: confirmation_token, # required
+      })
+      if resp.successful?
+        head :ok
+      else
+        head :not_acceptable
+      end
+    end
+  end
+
+  def verify_message_authenticity
+    verifier = Aws::SNS::MessageVerifier.new
+    if !verifier.authentic?(request.raw_post)
+      Rails.logger.info "Not an authentic SNS message - exiting"
+      head :not_acceptable
+    end
+  end
+
   def is_failure_notification?
     type == 'Notification' && status == 'FAILURE'
   end
 
-  def aws_message
-    @aws_message ||= AWS::SNS::Message.new request.raw_post
-  end
 
   def log_incoming_message
     Rails.logger.info request.raw_post
@@ -43,13 +63,20 @@ class Callbacks::AWSController < ApplicationController
     @status ||= json['status']
   end
 
+  def topic_arn
+    @topic_arn ||= json['TopicArn']
+  end
+
+  def confirmation_token
+    @confirmation_token ||= json['Token']
+  end
+
   def token
     @token ||= json['delivery']['token']
   end
 
-  # Weirdly, AWS double encodes the JSON.
   def json
-    @json ||= JSON.parse JSON.parse(request.raw_post)
+    @json ||= JSON.parse(request.raw_post)
   end
 
   def type

--- a/app/controllers/callbacks/aws_controller.rb
+++ b/app/controllers/callbacks/aws_controller.rb
@@ -1,0 +1,55 @@
+require 'json'
+
+# heavily influenced by the approach used in
+# http://www.downrightlies.net/posts/2015/05/19/setting-up-ses-on-aws-to-send-emails-from-rails.html
+class Callbacks::AWSController < ApplicationController
+
+  before_action :log_incoming_message
+
+  def push_failed
+    return render json: {} unless aws_message.authentic?
+
+    if type != 'Notification' || status != 'FAILURE'
+      Rails.logger.info "Not a Failure Notification - exiting"
+      return render json: {}
+    end
+
+    if subscription = DeviceSubscription.where({platform_device_identifier: token}).first
+        subscription.destroy
+    end
+
+    render json: {}
+  end
+
+  protected
+
+  def aws_message
+    @aws_message ||= AWS::SNS::Message.new request.raw_post
+  end
+
+  def log_incoming_message
+    Rails.logger.info request.raw_post
+  end
+
+  def status
+    @status ||= json['status']
+  end
+
+  def token
+    @token ||= json['delivery']['token']
+  end
+
+  # Weirdly, AWS double encodes the JSON.
+  def json
+    @json ||= JSON.parse JSON.parse(request.raw_post)
+  end
+
+  def type
+    request.headers['x-amz-sns-message-type']
+  end
+
+  def log_incoming_message
+    Rails.logger.info request.raw_post
+  end
+
+end

--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -1,0 +1,18 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see rails configuration guide
+  # http://guides.rubyonrails.org/configuring.html#database-pooling
+  pool: 5
+
+development:
+  <<: *default
+  database: ello-notifications_development
+
+test:
+  <<: *default
+  database: ello-notifications_test
+
+production:
+  url:  <%= ENV["DATABASE_URL"] %>
+  pool: <%= ENV["DB_POOL"] || ENV['MAX_THREADS'] || 5 %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,8 +10,14 @@ development:
   database: ello-notifications_development
 
 test:
-  <<: *default
+  adapter: postgresql
+  encoding: utf8
+  reconnect: false
   database: ello-notifications_test
+  pool: 5
+  host: 192.168.99.100
+  min_messages: error
+  username: postgres
 
 production:
   url:  <%= ENV["DATABASE_URL"] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,7 @@ Rails.application.routes.draw do
 
   post '/notifications/create' => 'notifications#create', as: :create_notification
 
+  post '/aws/push_failed' => 'aws#push_failed'
+
   get '/health_check' => 'status#health_check'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,4 @@
 Rails.application.routes.draw do
-  scope '/apns' do
-    resources :apns_subscriptions,
-      path: 'subscriptions',
-      param: :platform_device_identifier,
-      defaults: { format: :json },
-      only: [:create, :destroy]
-  end
-
   scope '/device_subscriptions' do
     post 'create' => 'device_subscriptions#create', as: :create_device_subscription
     post 'delete' => 'device_subscriptions#destroy', as: :delete_device_subscription

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   post '/notifications/create' => 'notifications#create', as: :create_notification
 
-  post '/aws/push_failed' => 'aws#push_failed'
+  post '/callbacks/aws/push_failed' => 'callbacks/aws#push_failed'
 
   get '/health_check' => 'status#health_check'
 end

--- a/spec/controllers/callbacks/aws_controller_spec.rb
+++ b/spec/controllers/callbacks/aws_controller_spec.rb
@@ -1,22 +1,117 @@
 require 'rails_helper'
 
-describe AWSController, type: :request do
+describe Callbacks::AwsController, type: :request do
+
+  before do
+    allow_any_instance_of(Aws::SNS::Client).to receive(:confirm_subscription)
+  end
+
+  let(:headers) { {} }
+  let(:body) { '' }
 
   describe 'POST #push_failed' do
+
+    context 'when verifying subscription' do
+
+      before do
+        allow_any_instance_of(Aws::SNS::Client).to receive(:confirm_subscription).and_return(confirmation_response)
+      end
+
+      let(:body) {{ Token: '123', TopicArn: '456'}}
+      let(:headers) do
+        {'x-amz-sns-message-type' => 'SubscriptionConfirmation',
+          'Content-Type' => 'application/json',
+          'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials('admin','admin')
+        }
+      end
+
+      context 'when the verification is successful' do
+        let(:confirmation_response) { instance_double("Seahorse::Client::Response", successful?: true) }
+
+        it 'returns a 200' do
+          post '/callbacks/aws/push_failed', body.to_json, headers
+          expect(response.status).to be(200)
+        end
+      end
+
+      context 'when the verification is unsuccessful' do
+        let(:confirmation_response) { instance_double("Seahorse::Client::Response", successful?: false) }
+
+        it 'returns a 406' do
+          post '/callbacks/aws/push_failed', body.to_json, headers
+          expect(response.status).to be(406)
+        end
+      end
+    end
+
     context 'with a validated message' do
+
+      before do
+        allow_any_instance_of(Aws::SNS::MessageVerifier).to receive(:authentic?).and_return(true)
+      end
+
       context 'message is a failed push notification' do
+        let!(:device_subscription) { create(:device_subscription, :gcm, platform_device_identifier: '123') }
+
+        let(:headers) do
+          {'x-amz-sns-message-type' => 'Notification',
+           'Content-Type' => 'application/json',
+           'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials('admin','admin')
+          }
+        end
+
+        let(:body) {{ delivery: { token: '123' }, status: 'FAILURE'}}
+
         it 'deletes the device subscription' do
+          expect(DeviceSubscription.find(device_subscription.id)).to be_truthy
+          post '/callbacks/aws/push_failed', body.to_json, headers
+          expect(response.status).to be(200)
+          expect(DeviceSubscription.find_by(id: device_subscription.id)).to be_nil
         end
       end
 
       context 'message is NOT a failed push notification' do
-        it 'exits immediately with an empty json' do
+
+        let!(:device_subscription) { create(:device_subscription, :gcm, platform_device_identifier: '123') }
+
+        let(:headers) do
+          {
+           'Content-Type' => 'application/json',
+           'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials('admin','admin')
+          }
+        end
+
+        let(:body) {{ deliver: { token: '123' }, status: 'NOT FAILURE'}}
+
+        it 'does not delete a device subscription' do
+          expect(DeviceSubscription.find(device_subscription.id)).to be_truthy
+          post '/callbacks/aws/push_failed', body.to_json, headers
+          expect(response.status).to be(200)
+          expect(DeviceSubscription.find(device_subscription.id)).to be_truthy
         end
       end
     end
 
     context 'with an unvalidated message' do
-      it 'exits immediately with an empty json' do
+
+      let!(:device_subscription) { create(:device_subscription, :gcm, platform_device_identifier: '123') }
+
+      let(:headers) do
+        {'x-amz-sns-message-type' => 'Notification',
+          'Content-Type' => 'application/json',
+          'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials('admin','admin')
+        }
+      end
+
+      before do
+        allow_any_instance_of(Aws::SNS::MessageVerifier).to receive(:authentic?).and_return(false)
+      end
+
+      it 'does not delete a device subscription' do
+        expect(DeviceSubscription.find(device_subscription.id)).to be_truthy
+        post '/callbacks/aws/push_failed', body.to_json, headers
+        expect(response.status).to be(406)
+        expect(DeviceSubscription.find(device_subscription.id)).to be_truthy
       end
     end
   end

--- a/spec/controllers/callbacks/aws_controller_spec.rb
+++ b/spec/controllers/callbacks/aws_controller_spec.rb
@@ -12,7 +12,7 @@ describe Callbacks::AwsController, type: :request do
 
   describe 'POST #push_failed' do
 
-    context "when verifying subscription" do
+    context 'when verifying subscription' do
 
       before do
         allow_any_instance_of(Aws::SNS::Client).to receive(:confirm_subscription).and_return(confirmation_response)
@@ -27,36 +27,36 @@ describe Callbacks::AwsController, type: :request do
         }
       end
 
-      context "when the verification is successful" do
+      context 'when the verification is successful' do
         let(:confirmation_response) {
-          instance_double("Seahorse::Client::Response", successful?: true)
+          instance_double('Seahorse::Client::Response', successful?: true)
         }
 
-        it "returns a 200" do
+        it 'returns a 200' do
           post '/callbacks/aws/push_failed', body.to_json, headers
           expect(response.status).to be(200)
         end
       end
 
-      context "when the verification is unsuccessful" do
+      context 'when the verification is unsuccessful' do
         let(:confirmation_response) {
-          instance_double("Seahorse::Client::Response", successful?: false)
+          instance_double('Seahorse::Client::Response', successful?: false)
         }
 
-        it "returns a 406" do
+        it 'returns a 406' do
           post '/callbacks/aws/push_failed', body.to_json, headers
           expect(response.status).to be(406)
         end
       end
     end
 
-    context "with a validated message" do
+    context 'with a validated message' do
 
       before do
         allow_any_instance_of(Aws::SNS::MessageVerifier).to receive(:authentic?).and_return(true)
       end
 
-      context "message is a failed push notification" do
+      context 'message is a failed push notification' do
         let!(:subscription) {
           create(:device_subscription, :gcm, platform_device_identifier: '123')
         }
@@ -71,7 +71,7 @@ describe Callbacks::AwsController, type: :request do
 
         let(:body) {{ delivery: { token: '123' }, status: 'FAILURE'}}
 
-        it "deletes the device subscription" do
+        it 'deletes the device subscription' do
           expect(DeviceSubscription.find(subscription.id)).to be_truthy
           post '/callbacks/aws/push_failed', body.to_json, headers
           expect(response.status).to be(200)
@@ -79,7 +79,7 @@ describe Callbacks::AwsController, type: :request do
         end
       end
 
-      context "message is NOT a failed push notification" do
+      context 'message is NOT a failed push notification' do
 
         let!(:subscription) {
           create(:device_subscription, :gcm, platform_device_identifier: '123')
@@ -94,7 +94,7 @@ describe Callbacks::AwsController, type: :request do
 
         let(:body) {{ deliver: { token: '123' }, status: 'NOT FAILURE'}}
 
-        it "does not delete a device subscription" do
+        it 'does not delete a device subscription' do
           expect(DeviceSubscription.find(subscription.id)).to be_truthy
           post '/callbacks/aws/push_failed', body.to_json, headers
           expect(response.status).to be(200)
@@ -103,7 +103,7 @@ describe Callbacks::AwsController, type: :request do
       end
     end
 
-    context "with an unvalidated message" do
+    context 'with an unvalidated message' do
 
       let!(:subscription) {
         create(:device_subscription, :gcm, platform_device_identifier: '123')
@@ -121,7 +121,7 @@ describe Callbacks::AwsController, type: :request do
         allow_any_instance_of(Aws::SNS::MessageVerifier).to receive(:authentic?).and_return(false)
       end
 
-      it "does not delete a device subscription" do
+      it 'does not delete a device subscription' do
         expect(DeviceSubscription.find(subscription.id)).to be_truthy
         post '/callbacks/aws/push_failed', body.to_json, headers
         expect(response.status).to be(406)

--- a/spec/controllers/callbacks/aws_controller_spec.rb
+++ b/spec/controllers/callbacks/aws_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 describe Callbacks::AwsController, type: :request do
+  Basic = ActionController::HttpAuthentication::Basic
 
   before do
     allow_any_instance_of(Aws::SNS::Client).to receive(:confirm_subscription)
@@ -11,7 +12,7 @@ describe Callbacks::AwsController, type: :request do
 
   describe 'POST #push_failed' do
 
-    context 'when verifying subscription' do
+    context "when verifying subscription" do
 
       before do
         allow_any_instance_of(Aws::SNS::Client).to receive(:confirm_subscription).and_return(confirmation_response)
@@ -19,87 +20,100 @@ describe Callbacks::AwsController, type: :request do
 
       let(:body) {{ Token: '123', TopicArn: '456'}}
       let(:headers) do
-        {'x-amz-sns-message-type' => 'SubscriptionConfirmation',
+        {
+          'x-amz-sns-message-type' => 'SubscriptionConfirmation',
           'Content-Type' => 'application/json',
-          'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials('admin','admin')
+          'HTTP_AUTHORIZATION' => Basic.encode_credentials('admin','admin')
         }
       end
 
-      context 'when the verification is successful' do
-        let(:confirmation_response) { instance_double("Seahorse::Client::Response", successful?: true) }
+      context "when the verification is successful" do
+        let(:confirmation_response) {
+          instance_double("Seahorse::Client::Response", successful?: true)
+        }
 
-        it 'returns a 200' do
+        it "returns a 200" do
           post '/callbacks/aws/push_failed', body.to_json, headers
           expect(response.status).to be(200)
         end
       end
 
-      context 'when the verification is unsuccessful' do
-        let(:confirmation_response) { instance_double("Seahorse::Client::Response", successful?: false) }
+      context "when the verification is unsuccessful" do
+        let(:confirmation_response) {
+          instance_double("Seahorse::Client::Response", successful?: false)
+        }
 
-        it 'returns a 406' do
+        it "returns a 406" do
           post '/callbacks/aws/push_failed', body.to_json, headers
           expect(response.status).to be(406)
         end
       end
     end
 
-    context 'with a validated message' do
+    context "with a validated message" do
 
       before do
         allow_any_instance_of(Aws::SNS::MessageVerifier).to receive(:authentic?).and_return(true)
       end
 
-      context 'message is a failed push notification' do
-        let!(:device_subscription) { create(:device_subscription, :gcm, platform_device_identifier: '123') }
+      context "message is a failed push notification" do
+        let!(:subscription) {
+          create(:device_subscription, :gcm, platform_device_identifier: '123')
+        }
 
         let(:headers) do
-          {'x-amz-sns-message-type' => 'Notification',
-           'Content-Type' => 'application/json',
-           'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials('admin','admin')
+          {
+            'x-amz-sns-message-type' => 'Notification',
+            'Content-Type' => 'application/json',
+            'HTTP_AUTHORIZATION' => Basic.encode_credentials('admin','admin')
           }
         end
 
         let(:body) {{ delivery: { token: '123' }, status: 'FAILURE'}}
 
-        it 'deletes the device subscription' do
-          expect(DeviceSubscription.find(device_subscription.id)).to be_truthy
+        it "deletes the device subscription" do
+          expect(DeviceSubscription.find(subscription.id)).to be_truthy
           post '/callbacks/aws/push_failed', body.to_json, headers
           expect(response.status).to be(200)
-          expect(DeviceSubscription.find_by(id: device_subscription.id)).to be_nil
+          expect(DeviceSubscription.find_by(id: subscription.id)).to be_nil
         end
       end
 
-      context 'message is NOT a failed push notification' do
+      context "message is NOT a failed push notification" do
 
-        let!(:device_subscription) { create(:device_subscription, :gcm, platform_device_identifier: '123') }
+        let!(:subscription) {
+          create(:device_subscription, :gcm, platform_device_identifier: '123')
+        }
 
         let(:headers) do
           {
            'Content-Type' => 'application/json',
-           'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials('admin','admin')
+           'HTTP_AUTHORIZATION' => Basic.encode_credentials('admin','admin')
           }
         end
 
         let(:body) {{ deliver: { token: '123' }, status: 'NOT FAILURE'}}
 
-        it 'does not delete a device subscription' do
-          expect(DeviceSubscription.find(device_subscription.id)).to be_truthy
+        it "does not delete a device subscription" do
+          expect(DeviceSubscription.find(subscription.id)).to be_truthy
           post '/callbacks/aws/push_failed', body.to_json, headers
           expect(response.status).to be(200)
-          expect(DeviceSubscription.find(device_subscription.id)).to be_truthy
+          expect(DeviceSubscription.find(subscription.id)).to be_truthy
         end
       end
     end
 
-    context 'with an unvalidated message' do
+    context "with an unvalidated message" do
 
-      let!(:device_subscription) { create(:device_subscription, :gcm, platform_device_identifier: '123') }
+      let!(:subscription) {
+        create(:device_subscription, :gcm, platform_device_identifier: '123')
+      }
 
       let(:headers) do
-        {'x-amz-sns-message-type' => 'Notification',
+        {
+          'x-amz-sns-message-type' => 'Notification',
           'Content-Type' => 'application/json',
-          'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials('admin','admin')
+          'HTTP_AUTHORIZATION' => Basic.encode_credentials('admin','admin')
         }
       end
 
@@ -107,11 +121,11 @@ describe Callbacks::AwsController, type: :request do
         allow_any_instance_of(Aws::SNS::MessageVerifier).to receive(:authentic?).and_return(false)
       end
 
-      it 'does not delete a device subscription' do
-        expect(DeviceSubscription.find(device_subscription.id)).to be_truthy
+      it "does not delete a device subscription" do
+        expect(DeviceSubscription.find(subscription.id)).to be_truthy
         post '/callbacks/aws/push_failed', body.to_json, headers
         expect(response.status).to be(406)
-        expect(DeviceSubscription.find(device_subscription.id)).to be_truthy
+        expect(DeviceSubscription.find(subscription.id)).to be_truthy
       end
     end
   end

--- a/spec/controllers/callbacks/aws_controller_spec.rb
+++ b/spec/controllers/callbacks/aws_controller_spec.rb
@@ -8,29 +8,26 @@ describe Callbacks::AwsController, type: :request do
   end
 
   let(:headers) { {} }
-  let(:body) { '' }
 
   describe 'POST #push_failed' do
-
     context 'when verifying subscription' do
-
       before do
         allow_any_instance_of(Aws::SNS::Client).to receive(:confirm_subscription).and_return(confirmation_response)
       end
 
-      let(:body) {{ Token: '123', TopicArn: '456'}}
+      let(:body) { { Token: '123', TopicArn: '456' } }
       let(:headers) do
         {
           'x-amz-sns-message-type' => 'SubscriptionConfirmation',
           'Content-Type' => 'application/json',
-          'HTTP_AUTHORIZATION' => Basic.encode_credentials('admin','admin')
+          'HTTP_AUTHORIZATION' => Basic.encode_credentials('admin', 'admin')
         }
       end
 
       context 'when the verification is successful' do
-        let(:confirmation_response) {
+        let(:confirmation_response) do
           instance_double('Seahorse::Client::Response', successful?: true)
-        }
+        end
 
         it 'returns a 200' do
           post '/callbacks/aws/push_failed', body.to_json, headers
@@ -39,9 +36,9 @@ describe Callbacks::AwsController, type: :request do
       end
 
       context 'when the verification is unsuccessful' do
-        let(:confirmation_response) {
+        let(:confirmation_response) do
           instance_double('Seahorse::Client::Response', successful?: false)
-        }
+        end
 
         it 'returns a 406' do
           post '/callbacks/aws/push_failed', body.to_json, headers
@@ -51,25 +48,24 @@ describe Callbacks::AwsController, type: :request do
     end
 
     context 'with a validated message' do
-
       before do
         allow_any_instance_of(Aws::SNS::MessageVerifier).to receive(:authentic?).and_return(true)
       end
 
       context 'message is a failed push notification' do
-        let!(:subscription) {
+        let!(:subscription) do
           create(:device_subscription, :gcm, platform_device_identifier: '123')
-        }
+        end
 
         let(:headers) do
           {
             'x-amz-sns-message-type' => 'Notification',
             'Content-Type' => 'application/json',
-            'HTTP_AUTHORIZATION' => Basic.encode_credentials('admin','admin')
+            'HTTP_AUTHORIZATION' => Basic.encode_credentials('admin', 'admin')
           }
         end
 
-        let(:body) {{ delivery: { token: '123' }, status: 'FAILURE'}}
+        let(:body) { { delivery: { token: '123' }, status: 'FAILURE' } }
 
         it 'deletes the device subscription' do
           expect(DeviceSubscription.find(subscription.id)).to be_truthy
@@ -80,19 +76,18 @@ describe Callbacks::AwsController, type: :request do
       end
 
       context 'message is NOT a failed push notification' do
-
-        let!(:subscription) {
+        let!(:subscription) do
           create(:device_subscription, :gcm, platform_device_identifier: '123')
-        }
+        end
 
         let(:headers) do
           {
-           'Content-Type' => 'application/json',
-           'HTTP_AUTHORIZATION' => Basic.encode_credentials('admin','admin')
+            'Content-Type' => 'application/json',
+            'HTTP_AUTHORIZATION' => Basic.encode_credentials('admin', 'admin')
           }
         end
 
-        let(:body) {{ deliver: { token: '123' }, status: 'NOT FAILURE'}}
+        let(:body) { { deliver: { token: '123' }, status: 'NOT FAILURE' } }
 
         it 'does not delete a device subscription' do
           expect(DeviceSubscription.find(subscription.id)).to be_truthy
@@ -104,16 +99,15 @@ describe Callbacks::AwsController, type: :request do
     end
 
     context 'with an unvalidated message' do
-
-      let!(:subscription) {
+      let!(:subscription) do
         create(:device_subscription, :gcm, platform_device_identifier: '123')
-      }
+      end
 
       let(:headers) do
         {
           'x-amz-sns-message-type' => 'Notification',
           'Content-Type' => 'application/json',
-          'HTTP_AUTHORIZATION' => Basic.encode_credentials('admin','admin')
+          'HTTP_AUTHORIZATION' => Basic.encode_credentials('admin', 'admin')
         }
       end
 

--- a/spec/controllers/callbacks/aws_controller_spec.rb
+++ b/spec/controllers/callbacks/aws_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe AWSController, type: :request do
+
+  describe 'POST #push_failed' do
+    context 'with a validated message' do
+      context 'message is a failed push notification' do
+        it 'deletes the device subscription' do
+        end
+      end
+
+      context 'message is NOT a failed push notification' do
+        it 'exits immediately with an empty json' do
+        end
+      end
+    end
+
+    context 'with an unvalidated message' do
+      it 'exits immediately with an empty json' do
+      end
+    end
+  end
+end


### PR DESCRIPTION
We've been seeing a rash of failed AWS SNS push failures with Android GCM. In order to better understand these we implemented a failure top subscription endpoint to remove failed device tokens.

This will hopefully reduce the number of failures and/or allow us to better understand the nature of the failures. The hypothesis is that GCM is frequently issuing new device tokens for existing devices, causing our notification service to fill up with invalid tokens.

We'll need to add the topic subscription in AWS before this gets merged.

![img](http://kelly.cybr.org/wp-content/uploads/2009/03/1926-switchboards.gif)