### PR TITLE
Give Honeybadger the protobuf request as context

### DIFF
--- a/app/controllers/device_subscriptions_controller.rb
+++ b/app/controllers/device_subscriptions_controller.rb
@@ -1,6 +1,7 @@
 class DeviceSubscriptionsController < ApplicationController
   def create
     protobuf_request = ElloProtobufs::NotificationService::CreateDeviceSubscriptionRequest.decode_from(request.body)
+    Honeybadger.context(protobuf_request: protobuf_request)
     result = CreateDeviceSubscription.call(request: protobuf_request)
 
     resp = service_response(result)
@@ -9,6 +10,7 @@ class DeviceSubscriptionsController < ApplicationController
 
   def destroy
     protobuf_request = ElloProtobufs::NotificationService::DeleteDeviceSubscriptionRequest.decode_from(request.body)
+    Honeybadger.context(protobuf_request: protobuf_request)
     result = DeleteDeviceSubscription.call(request: protobuf_request)
 
     resp = service_response(result)

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,9 +1,8 @@
 class NotificationsController < ApplicationController
   def create
     protobuf_request = ElloProtobufs::NotificationService::CreateNotificationRequest.decode_from(request.body)
-    result = CreateNotification.call({
-      request: protobuf_request
-    })
+    Honeybadger.context(protobuf_request: protobuf_request)
+    result = CreateNotification.call(request: protobuf_request)
 
     resp = service_response(result)
     render_protobuf_response(resp)


### PR DESCRIPTION
Otherwise we get very little context in the exception logs, which makes life more difficult.