### PR TITLE
Remove titles from push notifications

### DIFF
--- a/app/models/notification/factory.rb
+++ b/app/models/notification/factory.rb
@@ -13,14 +13,12 @@ class Notification::Factory
   end
 
   register_type ElloProtobufs::NotificationType::REPOST, 'repost' do |related_object|
-    title { I18n.t('notification_factory.repost.title') }
     body { I18n.t('notification_factory.repost.body', username: related_object.author.username) }
     application_target { "notifications/posts/#{related_object.id}" }
     web_url { related_object.href }
   end
 
   register_type ElloProtobufs::NotificationType::POST_COMMENT, 'post_comment' do |related_object|
-    title { I18n.t('notification_factory.post_comment.title') }
     body { I18n.t('notification_factory.post_comment.body', username: related_object.author.username) }
     application_target { "notifications/posts/#{related_object.parent_post.id}/comments/#{related_object.id}" }
     web_url { related_object.parent_post.href }
@@ -28,7 +26,6 @@ class Notification::Factory
 
   register_type ElloProtobufs::NotificationType::REPOST_COMMENT_TO_REPOST_AUTHOR,
                 'repost_comment_to_repost_author' do |related_object|
-    title { I18n.t('notification_factory.repost_comment_to_repost_author.title') }
     body do
       I18n.t('notification_factory.repost_comment_to_repost_author.body', username: related_object.author.username)
     end
@@ -38,7 +35,6 @@ class Notification::Factory
 
   register_type(ElloProtobufs::NotificationType::REPOST_COMMENT_TO_ORIGINAL_AUTHOR,
                 'repost_comment_to_original_author') do |related_object|
-    title { I18n.t('notification_factory.repost_comment_to_original_author.title') }
     body do
       I18n.t('notification_factory.repost_comment_to_original_author.body',
              username: related_object.author.username,
@@ -49,7 +45,6 @@ class Notification::Factory
   end
 
   register_type ElloProtobufs::NotificationType::POST_LOVE, 'post_love' do |related_object|
-    title { I18n.t('notification_factory.post_love.title') }
     body { I18n.t('notification_factory.post_love.body', username: related_object.user.username) }
     application_target { "notifications/posts/#{related_object.post.id}" }
     web_url { related_object.post.href }
@@ -57,7 +52,6 @@ class Notification::Factory
 
   register_type(ElloProtobufs::NotificationType::REPOST_LOVE_TO_REPOST_AUTHOR,
                 'repost_love_to_repost_author') do |related_object|
-    title { I18n.t('notification_factory.repost_love_to_repost_author.title') }
     body { I18n.t('notification_factory.repost_love_to_repost_author.body', username: related_object.user.username) }
     application_target { "notifications/posts/#{related_object.post.id}" }
     web_url { related_object.post.href }
@@ -65,7 +59,6 @@ class Notification::Factory
 
   register_type ElloProtobufs::NotificationType::REPOST_LOVE_TO_ORIGINAL_AUTHOR,
                 'repost_love_to_original_author' do |related_object|
-    title { I18n.t('notification_factory.repost_love_to_original_author.title') }
     body do
       I18n.t('notification_factory.repost_love_to_original_author.body',
              username: related_object.user.username,
@@ -76,28 +69,24 @@ class Notification::Factory
   end
 
   register_type ElloProtobufs::NotificationType::POST_MENTION, 'post_mention' do |related_object|
-    title { I18n.t('notification_factory.post_mention.title') }
     body { I18n.t('notification_factory.post_mention.body', username: related_object.author.username) }
     application_target { "notifications/posts/#{related_object.id}" }
     web_url { related_object.href }
   end
 
   register_type ElloProtobufs::NotificationType::COMMENT_MENTION, 'comment_mention' do |related_object|
-    title { I18n.t('notification_factory.comment_mention.title') }
     body { I18n.t('notification_factory.comment_mention.body', username: related_object.author.username) }
     application_target { "notifications/posts/#{related_object.parent_post.id}/comments/#{related_object.id}" }
     web_url { related_object.parent_post.href }
   end
 
   register_type ElloProtobufs::NotificationType::FOLLOWER, 'follower' do |related_object|
-    title { I18n.t('notification_factory.follower.title') }
     body { I18n.t('notification_factory.follower.body', username: related_object.username) }
     application_target { "notifications/users/#{related_object.id}" }
     web_url { related_object.href }
   end
 
   register_type ElloProtobufs::NotificationType::INVITE_REDEMPTION, 'invite_redemption' do |related_object|
-    title { I18n.t('notification_factory.invite_redemption.title') }
     body { I18n.t('notification_factory.invite_redemption.body', username: related_object.username) }
     application_target { "notifications/users/#{related_object.id}" }
     web_url { related_object.href }
@@ -108,14 +97,12 @@ class Notification::Factory
   end
 
   register_type ElloProtobufs::NotificationType::POST_WATCH, 'post_watch' do |related_object|
-    title { I18n.t('notification_factory.post_watch.title') }
     body { I18n.t('notification_factory.post_watch.body', username: related_object.user.username) }
     application_target { "notifications/posts/#{related_object.post.id}" }
     web_url { related_object.post.href }
   end
 
   register_type ElloProtobufs::NotificationType::POST_COMMENT_TO_WATCHER, 'post_comment_to_watcher' do |related_object|
-    title { I18n.t('notification_factory.post_comment_to_watcher.title') }
     body { I18n.t('notification_factory.post_comment_to_watcher.body', username: related_object.author.username) }
     application_target { "notifications/posts/#{related_object.parent_post.id}/comments/#{related_object.id}" }
     web_url { related_object.parent_post.href }
@@ -123,7 +110,6 @@ class Notification::Factory
 
   register_type ElloProtobufs::NotificationType::REPOST_WATCH_TO_REPOST_AUTHOR,
                 'repost_watch_to_repost_author' do |related_object|
-    title { I18n.t('notification_factory.repost_watch_to_repost_author.title') }
     body { I18n.t('notification_factory.repost_watch_to_repost_author.body', username: related_object.user.username) }
     application_target { "notifications/posts/#{related_object.post.id}" }
     web_url { related_object.post.href }
@@ -131,7 +117,6 @@ class Notification::Factory
 
   register_type ElloProtobufs::NotificationType::REPOST_WATCH_TO_ORIGINAL_AUTHOR,
                 'repost_watch_to_original_author' do |related_object|
-    title { I18n.t('notification_factory.repost_watch_to_original_author.title') }
     body do
       I18n.t('notification_factory.repost_watch_to_original_author.body',
              username: related_object.user.username,
@@ -142,10 +127,9 @@ class Notification::Factory
   end
 
   register_type ElloProtobufs::NotificationType::ANNOUNCEMENT, 'announcement' do |related_object|
-    title { I18n.t('notification_factory.announcement.title', header: related_object.header) }
-    body { I18n.t('notification_factory.announcement.body', body: related_object.body) }
-    application_target { related_object.cta_href }
-    web_url { related_object.cta_href }
+    body { I18n.t('notification_factory.announcement.body', header: related_object.header) }
+    application_target { 'notifications/' }
+    web_url { 'notifications/' }
   end
 
   def initialize(type, destination_user, related_object = nil)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,50 +5,34 @@ en:
         logged_in_user_id: "Logged in user id"
   notification_factory:
     repost:
-      title: 'New Repost'
       body: "%{username} has reposted one of your posts"
     post_comment:
-      title: 'New Comment'
       body: "%{username} commented on your post"
     repost_comment_to_repost_author:
-      title: 'New Comment on Your Repost'
       body: "%{username} commented on your repost"
     repost_comment_to_original_author:
-      title: 'New Comment on a Repost of Your Post'
       body: "%{username} commented on %{reposter_username}'s repost of your post"
     post_love:
-      title: 'New Love'
       body: "%{username} loved your post"
     repost_love_to_repost_author:
-      title: 'New Love on Your Repost'
       body: "%{username} loved your repost"
     repost_love_to_original_author:
-      title: 'New Love on a Repost of Your Post'
       body: "%{username} loved %{reposter_username}'s repost of your post"
     post_mention:
-      title: 'New Post Mention'
       body: "%{username} mentioned you in a post"
     comment_mention:
-      title: 'New Comment Mention'
       body: "%{username} mentioned you in a comment"
     follower:
-      title: 'New Follower'
       body: "%{username} is now following you"
     invite_redemption:
-      title: 'New Friends on Ello'
       body: "%{username} has accepted your invitation to join Ello"
     post_watch:
-      title: 'New Watcher on Post'
       body: "%{username} is watching your post"
     post_comment_to_watcher:
-      title: 'New Comment on a Watched Post'
       body: "%{username} commented on a post you're watching"
     repost_watch_to_repost_author:
-      title: 'New Watcher on a Repost'
       body: "%{username} is watching your repost"
     repost_watch_to_original_author:
-      title: 'New Watcher on a Reposted Post'
       body: "%{username} is watching %{reposter_username}'s repost of your post"
     announcement:
-      title: "%{header}"
-      body: "%{body}"
+      body: "%{header}"

--- a/spec/models/notification/factory_spec.rb
+++ b/spec/models/notification/factory_spec.rb
@@ -27,7 +27,6 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'repost' }
       let(:include_alert) { true }
-      let(:title) { 'New Repost' }
       let(:body) { "#{repost.author.username} has reposted one of your posts" }
       let(:application_target) { post_target(repost.id) }
       let(:web_url) { repost.href }
@@ -43,7 +42,6 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'post_comment' }
       let(:include_alert) { true }
-      let(:title) { 'New Comment' }
       let(:body) { "#{comment.author.username} commented on your post" }
       let(:application_target) { comment_target(comment.parent_post.id, comment.id) }
       let(:web_url) { comment.parent_post.href }
@@ -62,7 +60,6 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'repost_comment_to_repost_author' }
       let(:include_alert) { true }
-      let(:title) { 'New Comment on Your Repost' }
       let(:body) { "#{comment.author.username} commented on your repost" }
       let(:application_target) { comment_target(comment.parent_post.id, comment.id) }
       let(:web_url) { repost.href }
@@ -83,7 +80,6 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'repost_comment_to_original_author' }
       let(:include_alert) { true }
-      let(:title) { 'New Comment on a Repost of Your Post' }
       let(:body) do
         "#{comment.author.username} commented on #{comment.parent_post.author.username}'s repost of your post"
       end
@@ -101,7 +97,6 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'post_love' }
       let(:include_alert) { true }
-      let(:title) { 'New Love' }
       let(:body) { "#{love.user.username} loved your post" }
       let(:application_target) { post_target(love.post.id) }
       let(:web_url) { love.post.href }
@@ -122,7 +117,6 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'repost_love_to_repost_author' }
       let(:include_alert) { true }
-      let(:title) { 'New Love on Your Repost' }
       let(:body) { "#{love.user.username} loved your repost" }
       let(:application_target) { post_target(love.post.id) }
       let(:web_url) { love.post.href }
@@ -143,7 +137,6 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'repost_love_to_original_author' }
       let(:include_alert) { true }
-      let(:title) { 'New Love on a Repost of Your Post' }
       let(:body) { "#{love.user.username} loved #{love.post.author.username}'s repost of your post" }
       let(:application_target) { post_target(love.post.id) }
       let(:web_url) { love.post.href }
@@ -159,7 +152,6 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'post_mention' }
       let(:include_alert) { true }
-      let(:title) { 'New Post Mention' }
       let(:body) { "#{post.author.username} mentioned you in a post" }
       let(:application_target) { post_target(post.id) }
       let(:web_url) { post.href }
@@ -175,7 +167,6 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'comment_mention' }
       let(:include_alert) { true }
-      let(:title) { 'New Comment Mention' }
       let(:body) { "#{comment.author.username} mentioned you in a comment" }
       let(:application_target) { comment_target(comment.parent_post.id, comment.id) }
       let(:web_url) { comment.parent_post.href }
@@ -191,7 +182,6 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'follower' }
       let(:include_alert) { true }
-      let(:title) { 'New Follower' }
       let(:body) { "#{user.username} is now following you" }
       let(:application_target) { user_target(user.id) }
       let(:web_url) { user.href }
@@ -207,7 +197,6 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'invite_redemption' }
       let(:include_alert) { true }
-      let(:title) { 'New Friends on Ello' }
       let(:body) { "#{user.username} has accepted your invitation to join Ello" }
       let(:application_target) { user_target(user.id) }
       let(:web_url) { user.href }
@@ -221,7 +210,6 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'reset_badge_count' }
       let(:include_alert) { false }
-      let(:title) { nil }
       let(:body) { nil }
       let(:application_target) { nil }
       let(:web_url) { nil }
@@ -241,7 +229,6 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'post_watch' }
       let(:include_alert) { true }
-      let(:title) { 'New Watcher on Post' }
       let(:body) { "#{watch.user.username} is watching your post" }
       let(:application_target) { post_target(watch.post.id) }
       let(:web_url) { watch.post.href }
@@ -261,7 +248,6 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'post_comment_to_watcher' }
       let(:include_alert) { true }
-      let(:title) { 'New Comment on a Watched Post' }
       let(:body) { "#{comment.author.username} commented on a post you're watching" }
       let(:application_target) { comment_target(comment.parent_post.id, comment.id) }
       let(:web_url) { comment.parent_post.href }
@@ -282,7 +268,6 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'repost_watch_to_repost_author' }
       let(:include_alert) { true }
-      let(:title) { 'New Watcher on a Repost' }
       let(:body) { "#{watch.user.username} is watching your repost" }
       let(:application_target) { post_target(watch.post.id) }
       let(:web_url) { watch.post.href }
@@ -303,7 +288,6 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'repost_watch_to_original_author' }
       let(:include_alert) { true }
-      let(:title) { 'New Watcher on a Reposted Post' }
       let(:body) { "#{watch.user.username} is watching #{watch.post.author.username}'s repost of your post" }
       let(:application_target) { post_target(watch.post.id) }
       let(:web_url) { watch.post.href }
@@ -323,10 +307,9 @@ describe Notification::Factory do
       let(:destination_user_id) { destination_user.id }
       let(:type) { 'announcement' }
       let(:include_alert) { true }
-      let(:title) { 'Header' }
-      let(:body) { 'Body' }
-      let(:application_target) { 'http://asdf.com' }
-      let(:web_url) { 'http://asdf.com' }
+      let(:body) { announcement.header }
+      let(:application_target) { 'notifications/' }
+      let(:web_url) { 'notifications/' }
     end
   end
 

--- a/spec/support/shared_examples/a_notification_with.rb
+++ b/spec/support/shared_examples/a_notification_with.rb
@@ -4,10 +4,6 @@ RSpec.shared_examples 'a notification with' do
   # shared example expects that a number of params are defined as lets
   # in the calling spec -  e.g. `let(:title) { 'expected title' }`
 
-  it 'has the correct title' do
-    expect(subject.title).to eq(title)
-  end
-
   it 'sets the correct body' do
     expect(subject.body).to eq(body)
   end


### PR DESCRIPTION
We are doing away with titles in favor of only having a body (like the notifications below):

![image](https://cloud.githubusercontent.com/assets/11532712/20933875/9b87f548-bb96-11e6-912a-babc1dbae832.png)

/cc @alanpeabody @steam @jayzes 