### PR TITLE
Only subscribe ios 1.20 to announcements.

### DIFF
--- a/app/interactors/create_device_subscription.rb
+++ b/app/interactors/create_device_subscription.rb
@@ -53,7 +53,7 @@ class CreateDeviceSubscription
 
   def subscribe_to_announcements(device_sub)
     user = User.where(id: device_sub.logged_in_user_id).first_or_create
-    if user.notify_of_announcements
+    if user.notify_of_announcements && device_sub.supports_announcements?
       sub = SnsService.subscribe_to_announcements(device_sub.endpoint_arn)
       device_sub.update(announcement_subscription_arn: sub.arn)
     end

--- a/app/interactors/handle_stream_event.rb
+++ b/app/interactors/handle_stream_event.rb
@@ -47,7 +47,7 @@ class HandleStreamEvent
 
   def subscribe_all_user_devices
     device_subscriptions.each do |device|
-      unless device.announcement_subscription_arn
+      if device.supports_announcements? && !device.announcement_subscription_arn
         sub = SnsService.subscribe_to_announcements(device.endpoint_arn)
         device.update(announcement_subscription_arn: sub.arn)
         Rails.logger.debug("Subscribed arn #{sub.arn} to announcements")

--- a/app/models/device_subscription.rb
+++ b/app/models/device_subscription.rb
@@ -1,4 +1,5 @@
 class DeviceSubscription < ActiveRecord::Base
+  IOS_1_19 = 5507
   belongs_to :sns_application
 
   scope :enabled, -> { where(enabled: true) }
@@ -17,6 +18,10 @@ class DeviceSubscription < ActiveRecord::Base
 
   def can_handle_blank_pushes?
     build_version.to_i >= 3216
+  end
+
+  def supports_announcements?
+    gcm? || (build_version && build_version.to_i > IOS_1_19)
   end
 
   def apns?

--- a/lib/tasks/announcements.rake
+++ b/lib/tasks/announcements.rake
@@ -3,8 +3,10 @@ namespace :announcments do
   task subscribe_all: :environment do
     User.where(notify_of_announcements: true).find_each do |user|
       DeviceSubscription.enabled.where(logged_in_user_id: user.id, announcement_subscription_arn: nil).each do |device|
-        sub = SnsService.subscribe_to_announcements(device.endpoint_arn)
-        device.update(announcement_subscription_arn: sub.arn)
+        if device.supports_announcements?
+          sub = SnsService.subscribe_to_announcements(device.endpoint_arn)
+          device.update(announcement_subscription_arn: sub.arn)
+        end
       end
     end
   end

--- a/spec/interactors/create_device_subscription_spec.rb
+++ b/spec/interactors/create_device_subscription_spec.rb
@@ -14,7 +14,7 @@ describe CreateDeviceSubscription do
 
   let(:user) { create(:user) }
   let(:subscription) do
-    build(:device_subscription, :apns, logged_in_user_id: user.id, endpoint_arn: 'abc123')
+    build(:device_subscription, :apns, logged_in_user_id: user.id, endpoint_arn: 'abc123', build_version: 123456)
   end
 
   context 'when the device subscription is for APNS' do


### PR DESCRIPTION
Let's not send announcements to those who can not unsubscribe from them.