### PR TITLE
Update kinesis-stream-reader to get Librato source reporting back in place

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'pg'
 gem 'interactor', '~> 3.0'
 gem 'aws-sdk', '~> 2.2'
 gem 'ello_protobufs', github: 'ello/ello_protobufs', ref: 'c47addd'
-gem 'kinesis-stream-reader', require: 'stream_reader', github: 'ello/kinesis-stream-reader', ref: '6bcb5b5'
+gem 'kinesis-stream-reader', require: 'stream_reader', github: 'ello/kinesis-stream-reader', ref: 'bcab5da'
 gem 'retries'
 
 gem 'newrelic_rpm', '~> 3.12.0'

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development, :test do
 end
 
 gem 'rails-api'
-gem 'puma', '2.11.3'
+gem 'puma', '~> 3.4.0'
 
 gem 'pg'
 gem 'interactor', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,9 +162,8 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
-    puma (2.11.3)
-      rack (>= 1.1, < 2.0)
-    rack (1.6.4)
+    puma (3.4.0)
+    rack (1.6.5)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.7.1)
@@ -264,7 +263,7 @@ DEPENDENCIES
   newrelic_rpm (~> 3.12.0)
   pg
   pry-rails
-  puma (= 2.11.3)
+  puma (~> 3.4.0)
   rails (~> 4.2.5)
   rails-api
   rails_12factor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: git://github.com/ello/kinesis-stream-reader.git
-  revision: 6bcb5b5aa7b497bb9023fa860966645a722c8176
-  ref: 6bcb5b5
+  revision: bcab5daf4f21d0846b643d92370d336b5e4ce09b
+  ref: bcab5da
   specs:
     kinesis-stream-reader (0.2.0)
       activesupport
@@ -84,7 +84,7 @@ GEM
       railties (>= 3.0.0)
     faker (1.4.3)
       i18n (~> 0.5)
-    faraday (0.10.0)
+    faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.8)
     formatador (0.2.5)
@@ -109,7 +109,7 @@ GEM
     i18n (0.7.0)
     interactor (3.1.0)
     jmespath (1.3.1)
-    json (1.8.3)
+    json (1.8.6)
     json_spec (1.1.4)
       multi_json (~> 1.0)
       rspec (>= 2.0, < 4.0)


### PR DESCRIPTION
Also update Puma to 3.4.0 - we were running a pretty ancient version (2.11) previously and it would no longer compile when installing gems.