### PR TITLE
Rename 'content_mutable' key to 'mutable-content'

### DIFF
--- a/app/interactors/apns/deliver_notification.rb
+++ b/app/interactors/apns/deliver_notification.rb
@@ -28,7 +28,7 @@ class APNS::DeliverNotification
   def aps_options
     { badge: context[:notification].badge_count }.tap do |opts|
       if context[:notification].include_alert?
-        opts[:content_mutable] = true
+        opts[:'mutable-content'] = true
         opts[:category] = aps_category
         opts[:alert] = {
           title: context[:notification].title,

--- a/app/interactors/apns/deliver_notification.rb
+++ b/app/interactors/apns/deliver_notification.rb
@@ -28,7 +28,7 @@ class APNS::DeliverNotification
   def aps_options
     { badge: context[:notification].badge_count }.tap do |opts|
       if context[:notification].include_alert?
-        opts[:'mutable-content'] = true
+        opts['mutable-content'] = true
         opts[:category] = aps_category
         opts[:alert] = {
           title: context[:notification].title,

--- a/spec/interactors/apns/deliver_notification_spec.rb
+++ b/spec/interactors/apns/deliver_notification_spec.rb
@@ -52,7 +52,7 @@ describe APNS::DeliverNotification do
           'APNS_SANDBOX' => {
             aps: {
               badge: notification.badge_count,
-              content_mutable: true,
+              :'mutable-content' => true,
               category: 'co.ello.COMMENT_CATEGORY',
               alert: {
                 title: notification.title,
@@ -101,7 +101,7 @@ describe APNS::DeliverNotification do
           'APNS' => {
             aps: {
               badge: notification.badge_count,
-              content_mutable: true,
+              :'mutable-content' => true,
               category: 'co.ello.COMMENT_CATEGORY',
               alert: {
                 title: notification.title,

--- a/spec/interactors/apns/deliver_notification_spec.rb
+++ b/spec/interactors/apns/deliver_notification_spec.rb
@@ -52,7 +52,7 @@ describe APNS::DeliverNotification do
           'APNS_SANDBOX' => {
             aps: {
               badge: notification.badge_count,
-              :'mutable-content' => true,
+              'mutable-content' => true,
               category: 'co.ello.COMMENT_CATEGORY',
               alert: {
                 title: notification.title,
@@ -101,7 +101,7 @@ describe APNS::DeliverNotification do
           'APNS' => {
             aps: {
               badge: notification.badge_count,
-              :'mutable-content' => true,
+              'mutable-content' => true,
               category: 'co.ello.COMMENT_CATEGORY',
               alert: {
                 title: notification.title,


### PR DESCRIPTION
Fixes our push notifications on iOS.

[Finishes #149576537](https://www.pivotaltracker.com/story/show/149576537)